### PR TITLE
Fix "Christian Schulte" link on community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -59,7 +59,7 @@ headline: Community
   <h3>People</h3>
 
   <p>
-  Gecode was founded by <a href="https//chschulte.github.io">Christian
+  Gecode was founded by <a href="https://chschulte.github.io">Christian
   Schulte</a> (<a href="http://www.kth.se">KTH</a>, Sweden), who led
   the development until his
   passing <a href="https://www.a4cp.org/christian-in-memoriam">(ACP In


### PR DESCRIPTION
This PR has a very simple fix for a typo, to fix the link to Christian Schulte's website from the community page.